### PR TITLE
Fix a bug due to the operator precedence of C.

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -158,7 +158,7 @@ export(pic_state *pic, pic_value spec)
   } else {                      /* (export (rename a b)) */
     if (! pic_list_p(spec))
       goto fail;
-    if (! pic_length(pic, spec) == 3)
+    if (! (pic_length(pic, spec) == 3))
       goto fail;
     if (! pic_eq_p(pic_car(pic, spec), pic_sym_value(sRENAME)))
       goto fail;


### PR DESCRIPTION
The expression `! pic_length(pic, spec) == 3` is treated as `(!
pic_length(pic, spec)) == 3` since ! has higher precedence than ==.
