### PR TITLE
Fix a name of compiler identifier macro for Clang.

### DIFF
--- a/include/picrin/config.h
+++ b/include/picrin/config.h
@@ -42,7 +42,7 @@
 #endif
 
 #ifndef PIC_DIRECT_THREADED_VM
-# if defined(__GNUC__) || defined(__CLANG__)
+# if defined(__GNUC__) || defined(__clang__)
 #  define PIC_DIRECT_THREADED_VM 1
 # endif
 #endif


### PR DESCRIPTION
By the way, is `defined(__clang__)` needed even though Clang also defines `__GNUC__`?
