### PR TITLE
change %a to %f in number->string

### DIFF
--- a/number.c
+++ b/number.c
@@ -546,9 +546,9 @@ pic_number_number_to_string(pic_state *pic)
     return pic_obj_value(pic_make_str(pic, buf, sizeof buf - 1));
   }
   else {
-    char buf[snprintf(NULL, 0, "%a", f) + 1];
+    char buf[snprintf(NULL, 0, "%f", f) + 1];
 
-    snprintf(buf, sizeof buf, "%a", f);
+    snprintf(buf, sizeof buf, "%f", f);
 
     return pic_obj_value(pic_make_str(pic, buf, sizeof buf - 1));
   }


### PR DESCRIPTION
``` Scheme
> (number->string 5.5)
"0x1.6p+2"
```

I don't think this is the correct behaviour.
Fixed it by using %f instead of %a.
Awesome project btw!
